### PR TITLE
Automate CosmosDbContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,20 @@
 # fastify-cosmosDb
 
-This plugin shares [@azure/cosmosdb](https://www.npmjs.com/package/@azure/cosmos) object, so you can easy use CosmmosDb with fastify.
+[![Node.js CI](https://github.com/jeryanders/fastify-cosmosdb/actions/workflows/node.js.yml/badge.svg)](https://github.com/jeryanders/fastify-cosmosdb/actions/workflows/node.js.yml)
 
-This repo is WIP:
-
-- [ ] Publish to NPM
+This plugin shares [@azure/cosmosdb](https://www.npmjs.com/package/@azure/cosmos) object, so you can easy use CosmosDb with fastify.
 
 ## Install
 ```
 npm i fastify-cosmosdb -S
 ```
 ## Usage
-Register plugin with fastify. You can access the containers specified in the `cosmosConfiguration.containerIds` through the `cosmosDbContainers` decorating the fastify server: `fastify.cosmosDbContainers.containerOne.items('id')`
+Register plugin with fastify. You can access the containers specified in the `cosmosConfiguration.containerIds` through the `cosmosDbContainers` decorating the fastify server: `fastify.cosmosDbContainers.containerOne.items('id')`. Plugin will convert all sane container labels to canonical JavaScript camelCasedNames on the main container decoration.
+
 ```js
 const fastify = require('fastify')
 
-fastify.register(require('fastify-cosmosdb'), {A
+fastify.register(require('fastify-cosmosdb'), {
     cosmosOptions: {
       endpoint: 'http://localhost:8000',
       authKey: 'some-primary-or-secondary-key'
@@ -32,7 +31,7 @@ fastify.listen(3000, err => {
 })
 ```
 
-In your route file you can simply do all gets, queries, scans e.g.:
+Register your CosmosDb plugin with the following properties the `cosmosOptions` and the `cosmosConfiguration`. 
 
 ```js
 async function singleRoute(fastify, options) {

--- a/context/index.d.ts
+++ b/context/index.d.ts
@@ -1,0 +1,7 @@
+declare module 'context' {
+  export interface initializeDatabase {
+    (options: CosmosClientOptions, configuration: CosmosDbConfiguration): CosmosDbContext
+  }
+
+
+}

--- a/context/index.ts
+++ b/context/index.ts
@@ -1,0 +1,72 @@
+import { CosmosClient, CosmosClientOptions, DatabaseDefinition, Resource, FeedResponse, Container } from "@azure/cosmos";
+
+const normalizeSnakeCase = (str: string) => {
+  return str.split('-').map((word: string, index: number) => {
+    if (index === 0) return word.toLowerCase()
+
+    return word.slice(0, 1).toUpperCase() + word.slice(1).toLowerCase()
+  }).join('');
+}
+
+const camelize = (str: string) => {
+  if (str.indexOf('-') > 0) return normalizeSnakeCase(str)
+  return str.replace(/(?:^\w|[A-Z ]|\b\w)/g, function (word: string, index: number) {
+    return index === 0 ? word.toLowerCase() : word.toUpperCase()
+  }).replace(/\s+/g, '')
+}
+
+const initializeContainer = (client: CosmosClient, databaseId: string) => (containerId: string) => ([
+  camelize(containerId),
+  client.database(databaseId)
+    .container(containerId)
+])
+
+const initializeDatabase = (client: CosmosClient) => (databaseId: string) => ([
+  camelize(databaseId),
+  client.database(databaseId)
+    .containers.readAll().fetchAll()
+    .then(({ resources }) => {
+      const containerIds = resources.map((resource) => resource.id)
+      return Object.fromEntries(containerIds.map((initializeContainer(client, databaseId))))
+    })
+])
+
+function resolveAll<T> (promises: Promise<T>[]): any{
+  return Promise.all(
+    promises.map((promise: Promise<T>) => {
+      if (promise.then) {
+        return promise
+          .then((toResolve: (PromiseLike<T> | T)) =>
+                Array.isArray(toResolve)
+                  ? Promise.all(toResolve.map((resolve) => resolveAll(resolve)))
+                  : toResolve)
+      }
+
+      return promise
+    }))
+}
+
+type FastifyContainers = {
+  [key: string]: Container
+}
+
+export type FastifyCosmosDbClient = {
+  [key: string]: FastifyContainers
+}
+
+const processDatabases = (client: CosmosClient) => (databases: FeedResponse<DatabaseDefinition & Resource>): (string | Promise<any>)[][] => {
+  const databaseIds = databases.resources.map((resource) => resource.id)
+  const initializingDatabases = databaseIds.map(initializeDatabase(client))
+  return initializingDatabases
+}
+
+const context = (options: CosmosClientOptions): Promise<FastifyCosmosDbClient> => {
+  const cosmosClient = new CosmosClient(options)
+
+  return cosmosClient.databases.readAll().fetchAll()
+    .then(processDatabases(cosmosClient))
+    .then((databases) => Promise.all(databases.map((database: any) => resolveAll<FastifyContainers>(database))))
+    .then(Object.fromEntries)
+}
+
+export default context

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,7 @@
 import fp from 'fastify-plugin'
 import { FastifyPluginCallback } from 'fastify'
-import { CosmosClientOptions, CosmosClient, Database, Container } from '@azure/cosmos'
+import { CosmosClientOptions, Database, Container } from '@azure/cosmos'
+import context, { FastifyCosmosDbClient } from './context/index'
 
 export interface getCosmosDbClientFactory {
   (options: CosmosClientOptions, configuration: CosmosDbConfiguration): CosmosDbContext
@@ -32,39 +33,13 @@ export interface CosmosDbContainerContext {
   [key: string]: Container
 }
 
-function normalizeSnakeCase (str: string): string {
-  return str.split('-').map((word: string, index: number) => {
-    if (index === 0) return word.toLowerCase()
-
-    return word.slice(0, 1).toUpperCase() + word.slice(1).toLowerCase()
-  }).join('');
-}
-
-function camelize (str: string): string {
-  if (str.indexOf('-') > 0) return normalizeSnakeCase(str)
-  return str.replace(/(?:^\w|[A-Z]|\b\w)/g, function (word: string, index: number) {
-    return index === 0 ? word.toLowerCase() : word.toUpperCase()
-  }).replace(/\s+/g, '')
-}
-
-const getCosmosDbClientFactory = (options: CosmosClientOptions, configuration: CosmosDbConfiguration): [ Database, CosmosDbContainerContext ] => {
-  const cosmosClient = new CosmosClient(options)
-  const database = cosmosClient.database(configuration.databaseName)
-  const containerContextPairs = configuration.containerIds.map((containerId) => ([camelize(containerId), database.container(containerId)]))
-  const containerContexts = Object.fromEntries(containerContextPairs)
-  return [
-    database,
-    containerContexts
-  ];
-}
+const getCosmosDbClientFactory = (options: CosmosClientOptions): Promise<FastifyCosmosDbClient> => context(options)
 
 // define plugin using callbacks
 const cosmosDbContext: FastifyPluginCallback<CosmosPluginOptions> = (fastify, options, done) => {
   if (!fastify.cosmosDbContext) {
-    const [database, containers] = getCosmosDbClientFactory(options.cosmosOptions, options.cosmosConfiguration)
 
-    fastify.decorate('cosmosDbContext', database)
-    fastify.decorate('cosmosDbContainers', containers)
+    fastify.decorate('cosmosDbContext', getCosmosDbClientFactory(options.cosmosOptions))
   }
 
   done()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-cosmosdb",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "index.js",
   "types": "index.d.ts",
   "license": "MIT",


### PR DESCRIPTION
Instead of requiring a config to specify the ids used to pull in the database, the plugin will interrogate the databases and the containers to pull in all available collections of items with minimal config. I will allow for filtering by container and database id, but this will be validated against the cosmos client. 